### PR TITLE
Use container image from Candlepin officially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 IMAGE_NAME=quay.io/theforeman/candlepin
-IMAGE_TAG=4.4.14
+IMAGE_TAG=4.4.20-1
+
+PROJECT_XY_TAG=4.4
+PROJECT_XYZ_TAG=4.4.20
+
+FOREMAN_XY_TAG=3.15
+FOREMAN_XYZ_TAG=3.15.0
 
 build:
-	podman build -f images/candlepin/Containerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+	podman build --file images/candlepin/Containerfile --tag ${IMAGE_NAME}:${IMAGE_TAG} --build-arg TAG=${IMAGE_TAG}
+	podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${PROJECT_XY_TAG}
+	podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${PROJECT_XYZ_TAG}
+	podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${FOREMAN_XY_TAG}
+	podman tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${FOREMAN_XYZ_TAG}
 
 push:
-	podman push ${IMAGE_NAME}:${IMAGE_TAG}
+	podman push ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${PROJECT_XY_TAG} ${IMAGE_NAME}:${PROJECT_XYZ_TAG} ${IMAGE_NAME}:${FOREMAN_XY_TAG} ${IMAGE_NAME}:${FOREMAN_XYZ_TAG}

--- a/images/candlepin/Containerfile
+++ b/images/candlepin/Containerfile
@@ -1,11 +1,3 @@
-FROM quay.io/centos/centos:stream9
+ARG TAG=nightly
 
-RUN dnf -y update && \
-    dnf clean all
-
-RUN dnf -y --nodocs --setopt install_weak_deps=False install \
-    https://yum.theforeman.org/candlepin/4.4/el9/x86_64/candlepin-4.4.14-1.el9.noarch.rpm \
-    https://yum.theforeman.org/candlepin/4.4/el9/x86_64/candlepin-selinux-4.4.14-1.el9.noarch.rpm && \
-    dnf clean all
-
-CMD ["/usr/libexec/tomcat/server", "start"]
+FROM quay.io/candlepin/candlepin:${TAG}


### PR DESCRIPTION
This will re-use the Candlepin container image produced by the Candlepin project and then tags it according to the tagging rules using project and Foreman version tags.