### PR TITLE
Tag image with project and Foreman tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
-IMAGE_NAME=quay.io/theforeman/candlepin
-IMAGE_TAG=4.4.14
+IMAGE_NAME=quay.io/foreman/candlepin
+
+PROJECT_XY_TAG=4.4
+PROJECT_XYZ_TAG=${PROJECT_XY_TAG}.14
+
+FOREMAN_XY_TAG=foreman-3.16
+FOREMAN_XYZ_TAG=${FOREMAN_XY_TAG}.0
+
+IMAGE_TAGS=${IMAGE_NAME}:${PROJECT_XY_TAG} ${IMAGE_NAME}:${PROJECT_XYZ_TAG} ${IMAGE_NAME}:${FOREMAN_XY_TAG} ${IMAGE_NAME}:${FOREMAN_XYZ_TAG}
 
 build:
-	podman build -f images/candlepin/Containerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+	podman build --file images/candlepin/Containerfile --tag ${IMAGE_NAME}:${PROJECT_XYZ_TAG}	.
+	$(foreach tag,$(IMAGE_TAGS),\
+		podman tag ${IMAGE_NAME}:${PROJECT_XYZ_TAG} $(tag); \
+	)
 
 push:
-	podman push ${IMAGE_NAME}:${IMAGE_TAG}
+	$(foreach tag,$(IMAGE_TAGS),\
+		podman push $(tag);\
+	)


### PR DESCRIPTION
This produces:

```
podman tag quay.io/theforeman/candlepin:4.4.14 quay.io/theforeman/candlepin:4.4
podman tag quay.io/theforeman/candlepin:4.4.14 quay.io/theforeman/candlepin:4.4.14
podman tag quay.io/theforeman/candlepin:4.4.14 quay.io/theforeman/candlepin:3.16
podman tag quay.io/theforeman/candlepin:4.4.14 quay.io/theforeman/candlepin:3.16.0
```

This can produce a conflict and confusion about which tag is which and we did not specify in [the build design](https://github.com/theforeman/foreman-quadlet/blob/master/docs/container-image-builds.md) how to help clarify project vs. Foreman tag. Some options:


1. `quay.io/theforeman/candlepin:foreman-3.16.0`
2. `quay.io/theforeman316/candlepin:4.4.14`
3. `quay.io/theforeman/foreman-3.16-candlepin:4.4.14`