### PR TITLE
Support Java 25 for FFM support

### DIFF
--- a/images/candlepin/Containerfile
+++ b/images/candlepin/Containerfile
@@ -7,6 +7,9 @@ RUN dnf -y update && \
     dnf clean all
 
 RUN dnf -y --nodocs --setopt install_weak_deps=False install \
+    java-25-openjdk-headless \
+    openssl \
+    openssl-devel \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-${VERSION_XYZ}-1.el9.noarch.rpm \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-selinux-${VERSION_XYZ}-1.el9.noarch.rpm && \
     dnf clean all

--- a/images/candlepin/Containerfile
+++ b/images/candlepin/Containerfile
@@ -7,6 +7,9 @@ RUN dnf -y update && \
     dnf clean all
 
 RUN dnf -y --nodocs --setopt install_weak_deps=False install \
+    java-25-openjdk \
+    openssl \
+    openssl-devel \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-${VERSION_XYZ}-1.el9.noarch.rpm \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-selinux-${VERSION_XYZ}-1.el9.noarch.rpm && \
     dnf clean all


### PR DESCRIPTION
This will be needed once Candlepin supports Java 25, and to enable FFM support in Tomcat. FFM support is available in CentOS Stream 9 and 10 and allows configuring Tomcat with OpenSSL support instead of Java cryptography support.