### PR TITLE
images/candlepin: add OCI image labels

### DIFF
--- a/.tekton/candlepin-3-19-pull-request.yaml
+++ b/.tekton/candlepin-3-19-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       == "foreman-3.19" && ( "images/candlepin/***".pathChanged() || ".tekton/candlepin-3-19-pull-request.yaml".pathChanged()
       )
   labels:
-    appstudio.openshift.io/application: candlepin
+    appstudio.openshift.io/application: candlepin-3-19
     appstudio.openshift.io/component: candlepin-3-19
     pipelines.appstudio.openshift.io/type: build
   name: candlepin-3-19-on-pull-request

--- a/.tekton/candlepin-3-19-push.yaml
+++ b/.tekton/candlepin-3-19-push.yaml
@@ -11,7 +11,7 @@ metadata:
       == "foreman-3.19" && ( "images/candlepin/***".pathChanged() || ".tekton/candlepin-3-19-push.yaml".pathChanged()
       )
   labels:
-    appstudio.openshift.io/application: candlepin
+    appstudio.openshift.io/application: candlepin-3-19
     appstudio.openshift.io/component: candlepin-3-19
     pipelines.appstudio.openshift.io/type: build
   name: candlepin-3-19-on-push

--- a/images/candlepin/Containerfile
+++ b/images/candlepin/Containerfile
@@ -11,4 +11,9 @@ RUN dnf -y --nodocs --setopt install_weak_deps=False install \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-selinux-${VERSION_XYZ}-1.el9.noarch.rpm && \
     dnf clean all
 
+LABEL url="https://theforeman.org/" \
+      name="foreman/candlepin" \
+      description="Candlepin subscription management for the Foreman project" \
+      summary="Candlepin subscription management"
+
 CMD ["/usr/libexec/tomcat/server", "start"]


### PR DESCRIPTION
Add standard OCI image labels to the Containerfile for the foreman-3.19 branch.

Triggers the Konflux pull-request pipeline to validate the `candlepin-3-19` component build.