### PR TITLE
fix: use stage namespace for candlepin 3.19 output-image

### DIFF
--- a/.tekton/candlepin-3-19-pull-request.yaml
+++ b/.tekton/candlepin-3-19-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/candlepin-stage:on-pr-{{revision}}
+    value: quay.io/foreman/stage/candlepin:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/candlepin-3-19-push.yaml
+++ b/.tekton/candlepin-3-19-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/candlepin-stage:{{revision}}
+    value: quay.io/foreman/stage/candlepin:{{revision}}
   - name: dockerfile
     value: Containerfile
   - name: path-context


### PR DESCRIPTION
## Summary

Update `output-image` in Tekton push pipelines to use the new stage namespace convention.

**Before:** `quay.io/foreman/$service-stage:{{revision}}`
**After:** `quay.io/foreman/stage/$service:{{revision}}`

This aligns with theforeman/foremanctl#522, which changes stage image names to use a namespace instead of a name suffix, enabling registry override mirroring between stage and production.