### PR TITLE
chore(renovate): override tekton schedule to run at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["tekton"],
+      "schedule": ["at any time"]
+    }
+  ]
+}


### PR DESCRIPTION
Mintmaker's global config gates Konflux tekton reference updates to Saturdays only (`* 5-23 * * 6`). Override the schedule at the repo level so PRs are created as soon as new task bundle digests are available.