### PR TITLE
Run Candlepin container as tomcat non-root user

### DIFF
--- a/images/candlepin/Containerfile
+++ b/images/candlepin/Containerfile
@@ -14,4 +14,7 @@ RUN dnf -y --nodocs --setopt install_weak_deps=False install \
     https://yum.theforeman.org/candlepin/${VERSION}/el9/x86_64/candlepin-selinux-${VERSION_XYZ}-1.el9.noarch.rpm && \
     dnf clean all
 
+
+USER tomcat
+
 CMD ["/usr/libexec/tomcat/server", "start"]


### PR DESCRIPTION
## Summary
- Run the Candlepin container as the non-root `tomcat` user via `USER tomcat`
- Uses the existing Tomcat/Candlepin RPM user so runtime file ownership already matches

## Related
- foremanctl: (https://github.com/theforeman/foremanctl/pull/651)

## Test plan
- [x] `make build`
- [x] `podman run` image and confirm `id` is `tomcat` (not root)
- [x] Confirm writable access to cache/log/temp dirs used by Tomcat/Candlepin
- [x] Confirm Tomcat starts and binds its port
- [x] Load image into foremanctl quadlet VM, override `candlepin.image`, restart service
- [x] `systemctl is-active candlepin`
- [x] `podman exec candlepin id` → `uid=53(tomcat)`
- [x] `curl -k https://localhost:23443/candlepin/status` → `200`